### PR TITLE
Fix for build on Linux

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -39,6 +39,8 @@
 #include <cstring>
 #include <future>
 
+#include <deque>
+
 /** Maximum size of http request (request line + headers) */
 static const size_t MAX_HEADERS_SIZE = 8192;
 

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -645,7 +645,7 @@ int main(int argc, char *argv[]) {
     QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
 #endif
 #if QT_VERSION >= 0x050600
-    QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+    //QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 #endif
 #ifdef Q_OS_MAC
     QApplication::setAttribute(Qt::AA_DontShowIconsInMenus);

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -59,6 +59,10 @@
 
 #include <iostream>
 
+#include <boost/bind/bind.hpp>
+#include <boost/signals2/signal.hpp>
+using namespace boost::placeholders;
+
 const std::string BitcoinGUI::DEFAULT_UIPLATFORM =
 #if defined(Q_OS_MAC)
     "macosx"

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -27,6 +27,10 @@
 
 #include <cstdint>
 
+#include <boost/bind/bind.hpp>
+#include <boost/signals2/signal.hpp>
+using namespace boost::placeholders;
+
 class CBlockIndex;
 
 static int64_t nLastHeaderTipUpdateNotification = 0;

--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -25,6 +25,10 @@
 #include <QPainter>
 #include <QRadialGradient>
 
+#include <boost/bind/bind.hpp>
+#include <boost/signals2/signal.hpp>
+using namespace boost::placeholders;
+
 SplashScreen::SplashScreen(interfaces::Node &node, Qt::WindowFlags f,
                            const NetworkStyle *networkStyle)
     : QWidget(0, f), curAlignment(0), m_node(node) {

--- a/src/qt/trafficgraphwidget.h
+++ b/src/qt/trafficgraphwidget.h
@@ -8,6 +8,8 @@
 #include <QQueue>
 #include <QWidget>
 
+#include <QPainterPath>
+
 class ClientModel;
 
 QT_BEGIN_NAMESPACE

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -26,6 +26,10 @@
 #include <QIcon>
 #include <QList>
 
+#include <boost/bind/bind.hpp>
+#include <boost/signals2/signal.hpp>
+using namespace boost::placeholders;
+
 // Amount column is right-aligned it contains numbers
 static int column_alignments[] = {
     Qt::AlignLeft | Qt::AlignVCenter, /* status */

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -24,6 +24,10 @@
 
 #include <cstdint>
 
+#include <boost/bind/bind.hpp>
+#include <boost/signals2/signal.hpp>
+using namespace boost::placeholders;
+
 WalletModel::WalletModel(std::unique_ptr<interfaces::Wallet> wallet,
                          interfaces::Node &node,
                          const PlatformStyle *platformStyle,

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -54,6 +54,10 @@
 #include <sstream>
 #include <thread>
 
+#include <boost/bind/bind.hpp>
+#include <boost/signals2/signal.hpp>
+using namespace boost::placeholders;
+
 #if defined(NDEBUG)
 #error "Freecash cannot be compiled without assertions."
 #endif

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -19,6 +19,10 @@
 #include <future>
 #include <list>
 
+#include <boost/bind/bind.hpp>
+#include <boost/signals2/signal.hpp>
+using namespace boost::placeholders;
+
 struct MainSignalsInstance {
     boost::signals2::signal<void(const CBlockIndex *, const CBlockIndex *,
                                  bool fInitialDownload)>


### PR DESCRIPTION
While compiled freecoincash release 1.0.5 on Linux, fixed some mistakes in code: included libraries, commented out a QT dpi settings. I built without compiling depends, because I have installed those few dependencies.
My system:
```
~$ g++ --version
g++ (Debian 12.2.0-14) 12.2.0
Copyright (C) 2022 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

~$ gcc --version
gcc (Debian 12.2.0-14) 12.2.0
Copyright (C) 2022 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

~$ uname -a
Linux devuan 6.1.0-18-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.1.76-1 (2024-02-01) x86_64 GNU/Linux
~$ apt list --installed 2>&1 | grep boost
libboost-all-dev/stable,now 1.74.0.3 amd64 [installed]
```

Here it is full process log of first compilation and compilation of my own repository with fixes

```##2024-02-22 14:19 install FCH FreeCash 1.0.5 
wget https://github.com/freecashorg/freecash/archive/refs/tags/v1.0.5.tar.gz
tar -xf v1.0.5.tar.gz 
cd freecash-1.0.5/
#https://github.com/freecashorg/freecash/blob/master/doc/build-unix.md
head -1 depends/packages/packages.mk 
  packages:=boost openssl libevent zeromq
./autogen.sh
mkdir build
cd build
../configure --with-incompatible-bdb
make
  ../../src/amount.h:28:15: note: because ‘Amount’ has user-provided ‘constexpr Amount::Amount(const Amount&)’
     28 |     constexpr Amount(const Amount &_camount) : amount(_camount.amount) {}
        |               ^~~~~~
    CXX      libfreecash_server_a-httpserver.o
  ../../src/httpserver.cpp:77:10: error: ‘deque’ in namespace ‘std’ does not name a template type
     77 |     std::deque<std::unique_ptr<WorkItem>> queue;
vim ../src/httpserver.cpp
  42:#include <deque>
make
  ../../src/validation.cpp: In constructor ‘ConnectTrace::ConnectTrace(CTxMemPool&)’:
  ../../src/validation.cpp:2260:66: error: ‘_1’ was not declared in this scope
   2260 |             boost::bind(&ConnectTrace::NotifyEntryRemoved, this, _1, _2));
vim ../src/validation.cpp
  57:#include <boost/bind/bind.hpp>
  #include <boost/signals2/signal.hpp>
  using namespace boost::placeholders;
make
  ../../src/validationinterface.cpp:85:67: error: ‘_2’ was not declared in this scope
     85 |         boost::bind(&CMainSignals::MempoolEntryRemoved, this, _1, _2));
vim ../src/validationinterface.cpp
  22:#include <boost/bind/bind.hpp>
  #include <boost/signals2/signal.hpp>
  using namespace boost::placeholders;
  make
  ../../src/qt/bitcoingui.cpp: In member function ‘void BitcoinGUI::subscribeToCoreSignals()’:
  ../../src/qt/bitcoingui.cpp:1255:49: error: ‘_1’ was not declared in this scope
   1255 |         boost::bind(ThreadSafeMessageBox, this, _1, _2, _3));
vim ../src/qt/bitcoingui.cpp
  62:#include <boost/bind/bind.hpp>
  #include <boost/signals2/signal.hpp>
  using namespace boost::placeholders;
make
  ../../src/qt/clientmodel.cpp: In member function ‘void ClientModel::subscribeToCoreSignals()’:
  ../../src/qt/clientmodel.cpp:240:67: error: ‘_1’ was not declared in this scope
    240 |         m_node.handleShowProgress(boost::bind(ShowProgress, this, _1, _2));
vim ../src/qt/clientmodel.cpp
  30:#include <boost/bind/bind.hpp>
  #include <boost/signals2/signal.hpp>
  using namespace boost::placeholders;
make
  ../../src/qt/splashscreen.cpp:178:45: error: ‘_2’ was not declared in this scope
    178 |         boost::bind(ShowProgress, this, _1, _2, false)));
vim ../src/qt/splashscreen.cpp
  28:#include <boost/bind/bind.hpp>
  #include <boost/signals2/signal.hpp>
  using namespace boost::placeholders;
make
  ../../src/qt/trafficgraphwidget.cpp: In member function ‘void TrafficGraphWidget::paintPath(QPainterPath&, QQueue<float>&)’:
  ../../src/qt/trafficgraphwidget.cpp:45:9: error: invalid use of incomplete type ‘class QPainterPath’
     45 |         path.moveTo(x, YMARGIN + h);
vim ../src/qt/trafficgraphwidget.h
  11:#include <QPainterPath>
make
  ../../src/qt/transactiontablemodel.cpp: In member function ‘void TransactionTableModel::subscribeToCoreSignals()’:
  ../../src/qt/transactiontablemodel.cpp:771:57: error: ‘_1’ was not declared in this scope
    771 |             boost::bind(NotifyTransactionChanged, this, _1, _2));
vim ../src/qt/transactiontablemodel.cpp
  29:#include <boost/bind/bind.hpp>
  #include <boost/signals2/signal.hpp>
  using namespace boost::placeholders;
make
  ../../src/qt/walletmodel.cpp: In member function ‘void WalletModel::subscribeToCoreSignals()’:
  ../../src/qt/walletmodel.cpp:395:53: error: ‘_1’ was not declared in this scope
    395 |         boost::bind(NotifyAddressBookChanged, this, _1, _2, _3, _4, _5));
vim ../src/qt/walletmodel.cpp
  27:#include <boost/bind/bind.hpp>
  #include <boost/signals2/signal.hpp>
  using namespace boost::placeholders;
make
    CXX      script/libbitcoinconsensus_la-script.lo
    CXX      script/libbitcoinconsensus_la-script_error.lo
    CXX      script/libbitcoinconsensus_la-sigencoding.lo
    CXX      libbitcoinconsensus_la-uint256.lo
    CXX      libbitcoinconsensus_la-utilstrencodings.lo
    CXXLD    libbitcoinconsensus.la
  make[2]: Leaving directory '/mnt/disk-evo-500/crypto/testing/fch/freecash-1.0.5/build/src'
  make[1]: Leaving directory '/mnt/disk-evo-500/crypto/testing/fch/freecash-1.0.5/build/src'
  Making all in doc/man
  make[1]: Entering directory '/mnt/disk-evo-500/crypto/testing/fch/freecash-1.0.5/build/doc/man'
  make[1]: Nothing to be done for 'all'.
  make[1]: Leaving directory '/mnt/disk-evo-500/crypto/testing/fch/freecash-1.0.5/build/doc/man'
  make[1]: Entering directory '/mnt/disk-evo-500/crypto/testing/fch/freecash-1.0.5/build'
  make[1]: Nothing to be done for 'all-am'.
  make[1]: Leaving directory '/mnt/disk-evo-500/crypto/testing/fch/freecash-1.0.5/build'
./src/qt/freecash-qt
  ##2024-02-22 15:19 works, but with warning in terminal:
  Attribute Qt::AA_EnableHighDpiScaling must be set before QCoreApplication is created.
  ##same issue as in litecoincash
vim src/qt/bitcoin.cpp
  648://QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
cd build
../configure --with-incompatible-bdb
make
./src/qt/freecash-qt
  #works without warnings
```

Here it is compilation of my repository with fixes (and without any error):
```
  ##2024-02-22 15:59 now push fix
mkdir my-fix
cd my-fix/
git clone git@github.com:younicoin/freecash.git
cd freecash/
vim src/httpserver.cpp
  42:#include <deque>

vim src/validation.cpp
  57:#include <boost/bind/bind.hpp>
  #include <boost/signals2/signal.hpp>
  using namespace boost::placeholders;

vim src/validationinterface.cpp
  22:#include <boost/bind/bind.hpp>
  #include <boost/signals2/signal.hpp>
  using namespace boost::placeholders;
vim src/qt/bitcoingui.cpp
  62:#include <boost/bind/bind.hpp>
  #include <boost/signals2/signal.hpp>
  using namespace boost::placeholders;

vim src/qt/clientmodel.cpp
  30:#include <boost/bind/bind.hpp>
  #include <boost/signals2/signal.hpp>
  using namespace boost::placeholders;
vim src/qt/splashscreen.cpp
  28:#include <boost/bind/bind.hpp>
  #include <boost/signals2/signal.hpp>
  using namespace boost::placeholders;
vim src/qt/trafficgraphwidget.h
  11:#include <QPainterPath>
vim src/qt/transactiontablemodel.cpp
  29:#include <boost/bind/bind.hpp>
  #include <boost/signals2/signal.hpp>
  using namespace boost::placeholders;
vim src/qt/walletmodel.cpp
  27:#include <boost/bind/bind.hpp>
  #include <boost/signals2/signal.hpp>
  using namespace boost::placeholders;
vim src/qt/bitcoin.cpp
  648://QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
cd ..
cp -r freecash/ compile-freecash
cd compile-freecash
./autogen.sh
mkdir build && cd build
../configure --with-incompatible-bdb
make
  ##16:06:39 started to make. finished at Thu Feb 22 04:37:24 PM MSK 2024
./src/qt/freecash-qt
  ##works fine
```